### PR TITLE
Fix freetype-py dependency to not match >=2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -25,12 +25,12 @@ requirements:
     - setuptools
     - pillow >=9
     - rlpycairo >=0.2.0
-    - freetype-py >=2.3
+    - freetype-py >=2.3,<2.4
   run:
     - python
     - pillow >=9
     - rlpycairo >=0.2.0
-    - freetype-py >=2.3
+    - freetype-py >=2.3,<2.4
 
 test:
   imports:


### PR DESCRIPTION
The reportlab 4.0.0, 4.0.4 [source package](https://files.pythonhosted.org/packages/67/5f/096c281d19b10b68f6bbf3f1b773c8f83aa94c4aa2e0c8f07e9921fb2cdb/reportlab-4.0.4.tar.gz) `setup.py` constrains freetype-py to <2.4:
```
337             'pycairo': ['rlPyCairo>=0.2.0,<1', 'freetype-py>=2.3.0,<2.4']
```
This recipe doesn't. This means that anything downstream using reportlab from conda-forge without explicitly constraining freetype-py fails `pip check`:
```
% mamba create -yp ENV reportlab=4 && mamba activate ENV/ && pip check
...
reportlab 4.0.0 has requirement freetype-py<2.4,>=2.3.0, but you have freetype-py 2.4.0.
```

This PR changes the recipe to match.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
